### PR TITLE
Add Basic Makefile Variables

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,13 @@
+PREFIX ?= /usr/local
+CC ?= cc
+INSTALL ?= install
+
 all:
-	cc based-ssg.c libsmu.c -o based-ssg -march=native -std=c89 -O2
+	$(CC) based-ssg.c libsmu.c -o based-ssg -march=native -std=c89 -O2 $(CFLAGS)
 install:
-	cp based-ssg /usr/local/bin
+	$(INSTALL) -d $(PREFIX)/bin
+	$(INSTALL) based-ssg $(PREFIX)/bin/
 clean:
-	rm based-ssg
+	rm -f based-ssg
 uninstall:
-	rm /usr/local/bin/based-ssg
+	rm -f $(PREFIX)/bin/based-ssg


### PR DESCRIPTION
Title.

Specifically, many systems use slight variations of compilation tools and it's always good to be inclusive. The following modifications are suggested:

1. Creating a `PREFIX` variable makes it easier to modify the installation directory (although I'm not sure why you'd want to change it - but the idea still stands).
2. Systems with `gcc` as the default compiler `CC` will not throw issues during compilation.
3. Add the `CFLAGS` option to allow users to customize their compilation using various flags.
4. Using system native `INSTALL` is slightly better than the `cp` utility in most cases because it is generally universal and allows you to create directories and set installation permissions.
5. Added the `-f` flag to the `rm` command prevents `rm` from throwing errors if binary files do not yet exist.

If you're interested in make variables, you can read about [GNU makefile conventions](https://www.gnu.org/software/make/manual/html_node/Makefile-Conventions.html#Makefile-Conventions) or (since I notice you're more inclined to OpenBSD) you can read about [OpenBSD make](https://man.openbsd.org/make).

Keep up the good work! I'd love to see this project grow :)